### PR TITLE
Handle 404 on deallocate - stop rollback

### DIFF
--- a/app/uk/gov/hmrc/agentclientmandate/tasks/DeActivationTaskExecutor.scala
+++ b/app/uk/gov/hmrc/agentclientmandate/tasks/DeActivationTaskExecutor.scala
@@ -81,13 +81,15 @@ class DeActivationTaskService @Inject()(val etmpConnector: EtmpConnector,
           case NO_CONTENT =>
             metrics.incrementSuccessCounter(MetricsEnum.TaxEnrolmentDeallocate)
             Success(Next("finalize-deactivation", args))
+          case NOT_FOUND =>
+            metrics.incrementSuccessCounter(MetricsEnum.TaxEnrolmentDeallocate)
+            Success(Next("finalize-deactivation", args))
           case _ =>
             Logger.warn(s"[DeActivationTaskExecutor] - call to tax-enrolments failed with status ${resp.status} for mandate reference::${args("mandateId")}")
             metrics.incrementFailedCounter(MetricsEnum.TaxEnrolmentDeallocate)
             Failure(new Exception("Tax Enrolment call failed, status: " + resp.status))
         }
       case Failure(ex) =>
-
         Logger.warn(s"[DeActivationTaskExecutor] execption while calling deAllocateAgent :: ${ex.getMessage}")
         Failure(new Exception("Tax Enrolment call failed, status: " + ex.getMessage))
 

--- a/test/uk/gov/hmrc/agentclientmandate/tasks/DeActivationTaskExecutorSpec.scala
+++ b/test/uk/gov/hmrc/agentclientmandate/tasks/DeActivationTaskExecutorSpec.scala
@@ -273,6 +273,15 @@ class DeActivationTaskExecutorSpec extends TestKit(ActorSystem("activation-task"
         expectMsg(TaskCommand(StageComplete(Next("finalize-deactivation", Map("serviceIdentifier" -> "serviceIdentifier", "groupId" -> "groupId", "credId" -> "credId", "clientId" -> "clientId", "agentCode" -> "agentCode", "agentPartyId" -> "agentPartyId", "mandateId" -> "mandateId", "userType" -> "agent")), phaseCommit), message))
       }
 
+      "signal is Next('gg-proxy-deactivation', args) not found returned" in {
+        when(taxEnrolmentMock.deAllocateAgent(any(), any(), any(), any())(any())) thenReturn Future.successful(HttpResponse(NOT_FOUND))
+
+        val actorRef = system.actorOf(DeActivationTaskExecutorMock.props())
+
+        actorRef ! TaskCommand(StageComplete(nextSignalTaxEnrolment, phaseCommit), message)
+        expectMsg(TaskCommand(StageComplete(Next("finalize-deactivation", Map("serviceIdentifier" -> "serviceIdentifier", "groupId" -> "groupId", "credId" -> "credId", "clientId" -> "clientId", "agentCode" -> "agentCode", "agentPartyId" -> "agentPartyId", "mandateId" -> "mandateId", "userType" -> "agent")), phaseCommit), message))
+      }
+
       "signal is Next('gg-proxy-deactivation', args) failure code returned" in {
         when(taxEnrolmentMock.deAllocateAgent(any(), any(), any(), any())(any())) thenReturn Future.successful(HttpResponse(INTERNAL_SERVER_ERROR))
 


### PR DESCRIPTION
Bug fix - still seeing some fail events coming through on Grafana where there is an attempt to perform a deallocation but a 404 is returned because the allocation doesn't exist. 

We should be removing the allocation from the ACM database when this happens rather than rolling back and restoring it after so many failures. 